### PR TITLE
Fix for issue 2: --ignore-host does not work when receiving mail

### DIFF
--- a/mailgraph.pl
+++ b/mailgraph.pl
@@ -379,7 +379,7 @@ sub process_line($)
 					$text =~ /\brelay=[^\s\[]*\[127\.0\.0\.1\]/;
 				if(defined $opt{'ignore-host-re'}) {
 					for my $ih (@{$opt{'ignore-host-re'}}) {
-						warn "MATCH! $text\n" if $text =~ $ih;
+						warn "Ignore receiving host! $text\n" if $text =~ $ih;
 						return if $text =~ $ih;
 					}
 				}
@@ -421,8 +421,16 @@ sub process_line($)
 				my $client = $1;
 				return if $opt{'ignore-localhost'} and
 					$client =~ /\[127\.0\.0\.1\]$/;
-				return if $opt{'ignore-host'} and
-					$client =~ /$opt{'ignore-host'}/oi;
+				if(defined $opt{'ignore-host'}) {
+					#for my $ih (@{$opt{'ignore-host'}}) {
+					#	warn "Ignore sending host! $client\n" if $client =~ /$ih/i;
+					#	return if $client =~ /$ih/i;
+					#}
+					if( grep { $client =~ /$_/i } @{$opt{'ignore-host'}} ) {
+						warn "Ignore sending host! $client\n";
+						return;
+					}
+				}
 				if($text =~ /orig_client=\S+\[(\S+)\]/) {
 					my $client = $1;
 					my $ip = NetAddr::IP->new($client);


### PR DESCRIPTION
In receiving part, {'ignore-host'} was used as scalar. Handling as array fixed this.
