### PR TITLE
get mailgraph working on a Debian7 

### DIFF
--- a/README
+++ b/README
@@ -124,6 +124,10 @@ mailgraph is made of the following scripts:
 
   This is necessary in order mailgraph.pl is able to recognize it.
 
+- mailqueue.cron
+
+  This is the cronjob which calls mailqueue.sh
+
 - create_mailgraph_pics.pl
 
   This script generates just the pictures of your graphs. This is for people who don't
@@ -143,7 +147,7 @@ start mailgraph at system boot.
 You need to put mailgraph.cgi and probably mailgraph-imap.cgi on somewhere accessible though a web-server, it
 needs to be executeable and the web-server needs to execute it as a CGI.
 
-In order to count the mailqueue related values run mailqueue.sh every minute via cron.
+In order to count the mailqueue related values run mailqueue.sh every minute via cron (copy mailqueue.cron to /etc/cron.d/).
 
 Example for Installation paths:
 

--- a/create_mailgraph_pics.pl
+++ b/create_mailgraph_pics.pl
@@ -333,8 +333,8 @@ sub graph_imap($$)
         my ($range, $file) = @_;
         my $step = $range*$points_per_sample/$xpoints;
         rrd_graph($range, $file, $ypoints_imap,
-                "DEF:imaploginall=$rrd:imaploginall:AVERAGE",
-                "DEF:mimaploginall=$rrd:imaploginall:MAX",
+                "DEF:imaploginall=$rrd_imap:imaploginall:AVERAGE",
+                "DEF:mimaploginall=$rrd_imap:imaploginall:MAX",
                 "CDEF:rimaploginall=imaploginall,60,*",
                 "CDEF:rmimaploginall=mimaploginall,60,*",
                 "CDEF:dimaploginall=imaploginall,UN,0,imaploginall,IF,$step,*",
@@ -344,8 +344,8 @@ sub graph_imap($$)
                 'GPRINT:rimaploginall:AVERAGE:avg\: %5.2lf logins/min',
                 'GPRINT:rmimaploginall:MAX:max\: %4.0lf logins/min\l',
 
-                "DEF:imaploginfailed=$rrd:imaploginfailed:AVERAGE",
-                "DEF:mimaploginfailed=$rrd:imaploginfailed:MAX",
+                "DEF:imaploginfailed=$rrd_imap:imaploginfailed:AVERAGE",
+                "DEF:mimaploginfailed=$rrd_imap:imaploginfailed:MAX",
                 "CDEF:rimaploginfailed=imaploginfailed,60,*",
                 "CDEF:rmimaploginfailed=mimaploginfailed,60,*",
                 "CDEF:dimaploginfailed=imaploginfailed,UN,0,imaploginfailed,IF,$step,*",
@@ -413,11 +413,11 @@ sub main()
         	graph_grey($graphs[4]{seconds}, "$tmp_dir/$uri/mailgraph_grey_1y.png");
 
                 # create imap pngs
-                graph_imap($graphs[0]{seconds}, "$pic_dir/imapgraph_imap_1d.png");
-                graph_imap($graphs[1]{seconds}, "$pic_dir/imapgraph_imap_7d.png");
-                graph_imap($graphs[2]{seconds}, "$pic_dir/imapgraph_imap_4w.png");
-		graph_imap($graphs[3]{seconds}, "$pic_dir/imapgraph_imap_6m.png");
-                graph_imap($graphs[4]{seconds}, "$pic_dir/imapgraph_imap_1y.png");
+                graph_imap($graphs[0]{seconds}, "$tmp_dir/imapgraph_imap_1d.png");
+                graph_imap($graphs[1]{seconds}, "$tmp_dir/imapgraph_imap_7d.png");
+                graph_imap($graphs[2]{seconds}, "$tmp_dir/imapgraph_imap_4w.png");
+		graph_imap($graphs[3]{seconds}, "$tmp_dir/imapgraph_imap_6m.png");
+                graph_imap($graphs[4]{seconds}, "$tmp_dir/imapgraph_imap_1y.png");
 }
 
 main;

--- a/mailgraph-imap.cgi
+++ b/mailgraph-imap.cgi
@@ -24,7 +24,7 @@ my $ypoints_proto = 96;
 my $rrd = 'mailgraph.rrd'; # path to where the RRD database is
 my $rrd_virus = 'mailgraph_virus.rrd'; # path to where the Virus RRD database is
 my $rrd_imap = 'mailgraph_imap.rrd'; # path to where the Greylist RRD database is
-my $tmp_dir = '/tmp/mailgraph'; # temporary directory where to store the images
+my $tmp_dir = '/tmp/mailgraph-imap'; # temporary directory where to store the images
 
 # note: the following ranges must match with the RRA ranges
 # created in mailgraph.pl, otherwise the totals won't match.
@@ -311,13 +311,13 @@ HEADER
 <hr/>
 <table><tr><td>
 <a href="https://github.com/kokel/kokelnet-mailgraph">KokelNET Mailgraph</a> $VERSION
-by <a href="mailto:network@kokelnet.de">Tobias Hachmer</a></td>
+by <a href="mailto:network\@kokelnet.de">Tobias Hachmer</a></td>
 <td align="right">
-<a href="http://oss.oetiker.ch/rrdtool/"><img src="http://oss.oetiker.ch/rrdtool/.pics/rrdtool.gif" alt="" width="120" height="34"/></a>
+<a href="https://oss.oetiker.ch/rrdtool/"><img src="https://oss.oetiker.ch/rrdtool/.pics/rrdtool.gif" alt="" width="120" height="34"/></a>
 </td></tr>
 <tr><td>
-Based upon <a href="http://mailgraph.schweikert.ch/">Mailgraph</a>
-by <a href="http://david.schweikert.ch/">David Schweikert</a></td>
+Based upon <a href="https://mailgraph.schweikert.ch/">Mailgraph</a>
+by <a href="https://david.schweikert.ch/">David Schweikert</a></td>
 </td></tr>
 </table>
 </body></html>
@@ -333,7 +333,7 @@ sub send_image($)
 		exit 1;
 	};
 
-	print "Content-type: image/png\n" unless $ARGV[0];
+	print "Content-type: image/png\n\n";
 	print "Content-length: ".((stat($file))[7])."\n" unless $ARGV[0];
 	print "\n" unless $ARGV[0];
 	open(IMG, $file) or die;
@@ -382,3 +382,4 @@ sub main()
 }
 
 main;
+

--- a/mailgraph.cgi
+++ b/mailgraph.cgi
@@ -295,7 +295,7 @@ HEADER
 <hr/>
 <table><tr><td>
 <a href="https://github.com/kokel/kokelnet-mailgraph">KokelNET Mailgraph</a> $VERSION
-by <a href="mailto:network@kokelnet.de">Tobias Hachmer</a></td>
+by <a href="mailto:network\@kokelnet.de">Tobias Hachmer</a></td>
 <td align="right">
 <a href="http://oss.oetiker.ch/rrdtool/"><img src="http://oss.oetiker.ch/rrdtool/.pics/rrdtool.gif" alt="" width="120" height="34"/></a>
 </td></tr>
@@ -317,7 +317,7 @@ sub send_image($)
 		exit 1;
 	};
 
-	print "Content-type: image/png\n" unless $ARGV[0];
+	print "Content-type: image/png\n\n";
 	print "Content-length: ".((stat($file))[7])."\n" unless $ARGV[0];
 	print "\n" unless $ARGV[0];
 	open(IMG, $file) or die;
@@ -358,7 +358,7 @@ sub main()
 		}
 		elsif($img =~ /^(\d+)-q$/) {
 			my $file = "$tmp_dir/$uri/mailgraph_$1_queue.png";
-			graph_queue7($graphs[$1]{seconds}, $file);
+			graph_queue($graphs[$1]{seconds}, $file);
 			send_image($file);
 		}
 		else {
@@ -371,3 +371,4 @@ sub main()
 }
 
 main;
+

--- a/mailgraph.pl
+++ b/mailgraph.pl
@@ -18,7 +18,7 @@ use File::Tail;
 use Getopt::Long;
 use POSIX 'setsid';
 use Parse::Syslog;
-use Data::Validate::IP qw(is_ipv4 is_ipv6);
+use Net::IP qw(ip_is_ipv4 ip_is_ipv6);
 use NetAddr::IP;
 
 my $VERSION = "0.1";
@@ -390,10 +390,10 @@ sub process_line($)
 						my $network = NetAddr::IP->new($subnet);
 						return if $ip->within($network);
 					}
-					if(is_ipv4($relay)) {
+					if(ip_is_ipv4($relay)) {
 						event($time, 'ipv4');
 					}
-					elsif(is_ipv6($relay)) {
+					elsif(ip_is_ipv6($relay)) {
 						event($time, 'ipv6');
 					}
 					event($time, 'sent');
@@ -417,27 +417,24 @@ sub process_line($)
 			}
 		}
 		elsif($prog eq 'smtpd') {
-			if($text =~ /^[0-9A-Za-z]+: client=(\S+)/) {
+			if($text =~ /^(?:[\dA-F]+|[\dB-DF-HJ-NP-TV-Zb-df-hj-np-tv-z]+): client=(\S+)/) {
 				my $client = $1;
 				return if $opt{'ignore-localhost'} and
 					$client =~ /\[127\.0\.0\.1\]$/;
 				return if $opt{'ignore-host'} and
 					$client =~ /$opt{'ignore-host'}/oi;
-				if($text =~ /orig_client=\S+\[(\S+)\]/) {
-					my $client = $1;
 					my $ip = NetAddr::IP->new($client);
 					foreach $subnet (@subnets) {
 						my $network = NetAddr::IP->new($subnet);
 						return if $ip->within($network);
 					}
-					if(is_ipv4($client)) {
+					if(ip_is_ipv4($client)) {
 						event($time, 'ipv4');
 					}
-					elsif(is_ipv6($client)) {
+					elsif(ip_is_ipv6($client)) {
 						event($time, 'ipv6');
 					}
 					event($time, 'received');
-				}
 			}
 			elsif($opt{'virbl-is-virus'} and $text =~ /^(?:[0-9A-Za-z]+: |NOQUEUE: )?reject: .*: 554.* blocked using virbl.dnsbl.bit.nl/) {
 				event($time, 'virus');
@@ -750,10 +747,10 @@ sub process_line($)
                                 if($text =~ /TLS/) {
 					if($text =~ /rip\=(\S+)\,\slip\=/) {
 						my $client = $1;
-						if(is_ipv4($client)) {
+						if(ip_is_ipv4($client)) {
 							event($time, 'ipv4login');
 						}
-						elsif(is_ipv6($client)) {
+						elsif(ip_is_ipv6($client)) {
 							event($time, 'ipv6login');
 						}
 					}
@@ -763,10 +760,10 @@ sub process_line($)
                                 else {
 					if($text =~ /rip\=(\S+)\,\slip\=/) {
 						my $client = $1;
-						if(is_ipv4($client)) {
+						if(ip_is_ipv4($client)) {
 							event($time, 'ipv4login');
 						}
-						elsif(is_ipv6($client)) {
+						elsif(ip_is_ipv6($client)) {
 							event($time, 'ipv6login');
 						}
 					}
@@ -785,10 +782,10 @@ sub process_line($)
                                 if($text =~ /TLS/) {
 					if($text =~ /rip\=(\S+)\,\slip\=/) {
 						my $client = $1;
-						if(is_ipv4($client)) {
+						if(ip_is_ipv4($client)) {
 							event($time, 'ipv4login');
 						}
-						elsif(is_ipv6($client)) {
+						elsif(ip_is_ipv6($client)) {
 							event($time, 'ipv6login');
 						}
 					}
@@ -798,10 +795,10 @@ sub process_line($)
                                 else {
 					if($text =~ /rip\=(\S+)\,\slip\=/) {
 						my $client = $1;
-						if(is_ipv4($client)) {
+						if(ip_is_ipv4($client)) {
 							event($time, 'ipv4login');
 						}
-						elsif(is_ipv6($client)) {
+						elsif(ip_is_ipv6($client)) {
 							event($time, 'ipv6login');
 						}
 					}
@@ -1018,3 +1015,4 @@ S<David Schweikert E<lt>david@schweikert.chE<gt>>
 =cut
 
 # vi: sw=8
+

--- a/mailqueue.cron
+++ b/mailqueue.cron
@@ -1,0 +1,1 @@
+* * * * * root /usr/sbin/mailqueue.sh

--- a/mailqueue.sh
+++ b/mailqueue.sh
@@ -21,4 +21,4 @@ queuedir=`/usr/sbin/postconf -h queue_directory`
 active=`find $queuedir/incoming $queuedir/active $queuedir/maildrop -type f -print | wc -l | awk '{print $1}'`
 deferred=`find $queuedir/deferred -type f -print | wc -l | awk '{print $1}'`
 
-$LOGGER -t mailqueue active: $active, deferred: $deferred
+$LOGGER -p mail.info -t mailqueue active: $active, deferred: $deferred


### PR DESCRIPTION
I just committed all my changes here which where needed to get kokelnet-mailgraph (great extension of mailgraph! Thanks for this!) running on a debian 7 mail server (postfix/dovecot).

Most of the changes are not distribution related (minor fixes), but at least I'm not sure about perl library "Net::IP". The original code uses "Data::Validate::IP" (which is not available on debian 7) and the used function names seems to have changed (i.e. from "is_ipv6"  to "ip_is_ipv6" ).
